### PR TITLE
Use `NonNull`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@ impl AnyVec {
         // won't be able to access the dropped values.
         self.len = 0;
 
-        (self.drop_fn)(self.mem.as_ptr(), self.len);
+        (self.drop_fn)(self.mem.as_ptr(), len);
     }
 
     #[inline]


### PR DESCRIPTION
This allows `Option<AnyVec>` to have the same size as `AnyVec`. But the main reason I did this was to fix the null pointer deref that can occur when allocation fails by using the type-system to force us to handle that case with `handle_alloc_error`. Additionally, it fixes the UB of taking multiple unique references to `ZST_SLICE` by using `NonNull::dangling()` instead.