### PR TITLE
Fix UB in `clear()` that happens if dropping panics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,8 +205,13 @@ impl AnyVec {
 
     #[inline]
     pub fn clear(&mut self){
-        (self.drop_fn)(self.mem, self.len);
+        let len = self.len;
+
+        // Prematurely set the length to zero so that even if dropping the values panics users
+        // won't be able to access the dropped values.
         self.len = 0;
+
+        (self.drop_fn)(self.mem, len);
     }
 
     #[inline]


### PR DESCRIPTION
Previously a panicking destructor would cause `clear` to return but the length not to be set to zero, allowing users to access a value that has been dropped. By prematurely setting the length to zero this problem is avoided. 